### PR TITLE
Remove sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ cp default.env .env
 ### Start Services
 
 ```
-sudo docker-compose up --detach
+docker-compose up --detach
 ```
 
 ### Reset database
@@ -21,10 +21,10 @@ sudo docker-compose up --detach
 For clean slate, stop the service and remove the volume, then restart: 
 
 ```
-sudo docker-compose down
+docker-compose down
 docker volume ls
 docker volume rm <volume_name>
-sudo docker-compose up --detach
+docker-compose up --detach
 ```
 
 ### Import database

--- a/tnth/aliases
+++ b/tnth/aliases
@@ -1,1 +1,2 @@
 dc='sudo docker-compose'
+docker='sudo docker'


### PR DESCRIPTION
`sudo` may or may not be required depending on how docker was deployed. I believe it's up to the user to know whether sudo is required or not

* Remove `sudo` invocations
* Add alias for `docker` to `sudo docker`
