### PR TITLE
Utility to anonymize production db for testing purposes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.env
 *__pycache__
 *venv
+**/custom/

--- a/tnth/prod-anon.yaml
+++ b/tnth/prod-anon.yaml
@@ -1,0 +1,33 @@
+services:
+  postgres:
+    image: postgres:${POSTGRES_VERSION:-16}
+    environment:
+      # use generic postgres env vars to configure env vars specific to dockerized postgres
+      POSTGRES_DB: ${PGDATABASE:-portaldb}
+      POSTGRES_PASSWORD: ${PGPASSWORD:-wplatrop}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d portaldb"]
+      interval: 5s
+      retries: 3
+      start_period: 10s
+      timeout: 5s
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - "./custom/db:/docker-entrypoint-initdb.d"
+    ports:
+      # only listen on localhost
+      - "127.0.0.1:5432:5432"
+
+  prodanon:
+    build: ./prodanon
+    environment:
+      # use generic postgres env vars to configure env vars specific to dockerized postgres
+      POSTGRES_HOST: postgres
+      POSTGRES_DB: ${PGDATABASE:-portaldb}
+      POSTGRES_PASSWORD: ${PGPASSWORD:-wplatrop}
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+    postgres-data: {}

--- a/tnth/prodanon/Dockerfile
+++ b/tnth/prodanon/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.9
+WORKDIR /src
+COPY requirements.txt /src
+RUN pip install -r requirements.txt
+COPY . /src
+CMD ["python", "-u", "anonymize.py"]

--- a/tnth/prodanon/anonymize.py
+++ b/tnth/prodanon/anonymize.py
@@ -1,0 +1,31 @@
+import importlib
+import os
+from prodanon.conn import Conn
+
+def test_connection(cursor):
+    cursor.execute("SELECT version();")
+    version = cursor.fetchone()
+    assert version[0].startswith('PostgreSQL ')
+
+
+package = "prodanon"
+transformers_dir = os.path.join(os.path.dirname(__file__), package, "transformers")
+custom_dir = os.path.join(os.path.dirname(__file__), package, "custom")
+
+if __name__ == '__main__':
+    print("Begin Anonymize Data")
+
+    transformers = [
+        f[:-3] for f in os.listdir(transformers_dir) if f.endswith(".py") and f != "__init__.py"]
+    with Conn() as cursor:
+        test_connection(cursor)
+
+        for transformer_module in transformers:
+            module_path = f"{package}.transformers.{transformer_module}"
+            module = importlib.import_module(module_path)
+            if not hasattr(module, "transform"):
+                raise ValueError(f"expected `transform()` function not found in {module_path}")
+            print(f"Calling `{transformer_module}.transform()`")
+            module.transform(cursor, custom_dir)
+
+    print("Anonymize Data Complete")

--- a/tnth/prodanon/anonymize.py
+++ b/tnth/prodanon/anonymize.py
@@ -5,7 +5,8 @@ from prodanon.conn import Conn
 def test_connection(cursor):
     cursor.execute("SELECT version();")
     version = cursor.fetchone()
-    assert version[0].startswith('PostgreSQL ')
+    if not version[0].startswith('PostgreSQL '):
+        raise RuntimeError("Unable to connect to PostgreSQL; Can't continue")
 
 
 package = "prodanon"

--- a/tnth/prodanon/prodanon/config.py
+++ b/tnth/prodanon/prodanon/config.py
@@ -3,7 +3,7 @@ import os
 class Config(object):
     db_host = os.environ.get("POSTGRES_HOST", '127.0.0.1')
     db_port = os.environ.get("POSTGRES_PORT", '5432')
-    db_name = os.environ.get("POSTGRES_DB")
+    db_name = os.environ.get("POSTGRES_DB", "portaldb")
     db_user = os.environ.get("POSTGRES_USER", 'postgres')
     db_password = os.environ.get("POSTGRES_PASSWORD")
 

--- a/tnth/prodanon/prodanon/config.py
+++ b/tnth/prodanon/prodanon/config.py
@@ -1,0 +1,20 @@
+import os
+
+class Config(object):
+    db_host = os.environ.get("POSTGRES_HOST", '127.0.0.1')
+    db_port = os.environ.get("POSTGRES_PORT", '5432')
+    db_name = os.environ.get("POSTGRES_DB")
+    db_user = os.environ.get("POSTGRES_USER", 'postgres')
+    db_password = os.environ.get("POSTGRES_PASSWORD")
+
+    @staticmethod
+    def connection_args():
+        return {
+            "host": Config.db_host,
+            "port": Config.db_port,
+            "database": Config.db_name,
+            "user": Config.db_user,
+            "password": Config.db_password,
+        }
+
+    test_user_email = os.environ.get("TEST_USER_EMAIL", 'test@example.com')

--- a/tnth/prodanon/prodanon/conn.py
+++ b/tnth/prodanon/prodanon/conn.py
@@ -1,0 +1,28 @@
+import psycopg2
+from .config import Config
+
+class Conn(object):
+    connection = None
+    cursor = None
+
+    def __init__(self):
+        if self.connection is None:
+            self.connection = psycopg2.connect(**Config.connection_args())
+
+    def __enter__(self):
+        self.cursor = self.connection.cursor()
+        return self.cursor
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is None:
+            self.connection.commit()
+        else:
+            self.connection.rollback()
+
+        if self.cursor:
+            self.cursor.close()
+        if self.connection:
+            self.connection.close()
+
+        # Return false to propagate any exception (if raised)
+        return False

--- a/tnth/prodanon/prodanon/custom/config.yaml.default
+++ b/tnth/prodanon/prodanon/custom/config.yaml.default
@@ -1,3 +1,4 @@
+# example config; copy and add client/intervention details as needed
 clients:
   - name: ae
     # the original dev `ae` client details, to be restored for functional integration

--- a/tnth/prodanon/prodanon/custom/config.yaml.default
+++ b/tnth/prodanon/prodanon/custom/config.yaml.default
@@ -1,0 +1,33 @@
+clients:
+  - name: ae
+    # the original dev `ae` client details, to be restored for functional integration
+    client_id: 
+    client_secret: 
+    user_id: 
+    _redirect_uris: https://ae-eproms-test.cirg.washington.edu
+    _default_scopes: email
+    callback_url: https://ae-eproms-test.cirg.washington.edu/auth/truenth/eventcallback
+    intervention_name: 'assessment engine'
+
+  - name: mskcc
+    # the original dev metadata rave uat client, needed for long life token
+    client_id: 
+    client_secret: 
+    user_id:
+    _redirect_uris: https://mskcc.mdsol.com
+    _default_scopes: email
+    callback_url: null
+    intervention_name: null
+
+users:
+  preserve_ids: []
+
+tokens:
+  - name: mskcc
+    client_id:
+    user_id:
+    token_type: Bearer
+    access_token:
+    expires:
+    _scopes: email
+

--- a/tnth/prodanon/prodanon/transformers/audit.py
+++ b/tnth/prodanon/prodanon/transformers/audit.py
@@ -1,0 +1,41 @@
+"""Module to anonymize all PHI fields in Audit table
+
+Audit records fit into clean `context` buckets.  Most are benign, but a few
+need cleanup.
+
+'access': clean
+'account': has a few `registered invited user %` with PHI
+'assessment': clean
+'authentication': has a few `Failed identity challenge %` with PHI
+'consent': clean
+'eproms': clean
+'intervention': clean
+'login': clean
+'observation': clean
+'organization': clean
+'other': clean
+'postgres': clean
+'procedure': clean
+'role': clean
+'tou': clean
+'user': tons of PHI - redact all comments.  Could be more selective if testing needs warrant.
+"""
+def transform(cursor, custom_dir):
+    cursor.execute(
+        "SELECT id, context, comment FROM audit "
+        "WHERE context in ('account', 'authentication', 'user');")
+    updates = []
+
+    for id, context, comment in cursor:
+        if context == 'account':
+            if comment.startswith('registered invited user'):
+                updates.append((id, "registered invited user <redacted>"))
+        if context == 'authentication':
+            if comment.startswith('Failed identity challenge'):
+                updates.append((id, "Failed identity challenge <redacted>"))
+        if context == 'user':
+            updates.append((id, "<redacted>"))
+
+    print(f"Updating {len(updates)} audit rows")
+    for id, comment in updates:
+        cursor.execute(f"UPDATE audit set comment='{comment}' WHERE id={id}")

--- a/tnth/prodanon/prodanon/transformers/clients.py
+++ b/tnth/prodanon/prodanon/transformers/clients.py
@@ -48,25 +48,3 @@ def transform(cursor, custom_dir):
     with open(os.path.join(custom_dir, "config.yaml"), 'r') as yamldata:
         for client in yaml.safe_load(yamldata)['clients']:
             insert_client(cursor, client)
-
-
-def unused(cursor, ae):
-    # plug in dev version of assessment engine for functional interaction
-    # already in place, implies this is the second run of the transformation
-    # ignore for easier use in development
-    cursor.execute("SELECT count(*) FROM clients WHERE client_id='%s'" % ae['client_id'])
-    if cursor.fetchone()[0] == 1:
-        return
-
-    print(f"Replacing assessment engine client details as named in `config.yaml`")
-    values = (
-        ae['client_id'], ae['client_secret'], ae['user_id'], ae['_redirect_uris'],
-        ae['_default_scopes'], ae['callback_url'])
-    insert_clause = (
-        "INSERT INTO clients (client_id, client_secret, user_id, _redirect_uris, "
-        "_default_scopes, callback_url) VALUES ('%s', '%s', %s, '%s', '%s', '%s')")
-
-    cursor.execute(insert_clause % values)
-    cursor.execute(
-        "UPDATE interventions SET client_id = '%s' WHERE name = 'assessment engine'" %
-        ae['client_id'])

--- a/tnth/prodanon/prodanon/transformers/clients.py
+++ b/tnth/prodanon/prodanon/transformers/clients.py
@@ -1,0 +1,72 @@
+"""Module to re-create dev specific clients
+
+The prod-anon process brings over all prod specific data.  Clients is an exception
+where the configured dev clients need to be preserved, to maintain integration
+with other dev services
+
+"""
+import os
+import yaml
+
+
+def insert_client(cursor, client):
+    # insert a client similar to the original dev/test values, for functional integration
+    # with existing services (i.e. assessment engine or clients with long life tokens)
+
+    # skip out if a match is found; simplifies development cycles
+    cursor.execute("SELECT count(*) FROM clients WHERE client_id='%s'" % client['client_id'])
+    if cursor.fetchone()[0] == 1:
+        return
+
+    print("Inserting client '%s'" % client['name'])
+    values = (
+        client['client_id'], client['client_secret'], client['user_id'], client['_redirect_uris'],
+        client['_default_scopes'], client['callback_url'])
+    insert_clause = (
+        "INSERT INTO clients (client_id, client_secret, user_id, _redirect_uris, "
+        "_default_scopes, callback_url) VALUES ('%s', '%s', %s, '%s', '%s', '%s')")
+
+    cursor.execute(insert_clause % values)
+
+    if client['intervention_name']:
+        cursor.execute(
+            "UPDATE interventions SET client_id = '%s' WHERE name = '%s'" %
+            client['client_id'], client['intervention_name'])
+
+
+def transform(cursor, custom_dir):
+    """AE needs to point to the old dev version, as described in the custom/config.yaml"""
+    # modify all existing prod client redirect uris to avoid any accidental interaction
+    cursor.execute("SELECT client_id, _redirect_uris FROM clients ")
+    updates = []
+    for id, uri in cursor:
+        updates.append((id, f"<disabled>{uri}"))
+    print(f"Updating {len(updates)} client rows")
+    for id, uri in updates:
+        cursor.execute(f"UPDATE clients set _redirect_uris='{uri}' WHERE client_id='{id}'")
+
+    with open(os.path.join(custom_dir, "config.yaml"), 'r') as yamldata:
+        for client in yaml.safe_load(yamldata)['clients']:
+            insert_client(cursor, client)
+
+
+def unused(cursor, ae):
+    # plug in dev version of assessment engine for functional interaction
+    # already in place, implies this is the second run of the transformation
+    # ignore for easier use in development
+    cursor.execute("SELECT count(*) FROM clients WHERE client_id='%s'" % ae['client_id'])
+    if cursor.fetchone()[0] == 1:
+        return
+
+    print(f"Replacing assessment engine client details as named in `config.yaml`")
+    values = (
+        ae['client_id'], ae['client_secret'], ae['user_id'], ae['_redirect_uris'],
+        ae['_default_scopes'], ae['callback_url'])
+    insert_clause = (
+        "INSERT INTO clients (client_id, client_secret, user_id, _redirect_uris, "
+        "_default_scopes, callback_url) VALUES ('%s', '%s', %s, '%s', '%s', '%s')")
+
+    cursor.execute(insert_clause % values)
+    cursor.execute(
+        "UPDATE interventions SET client_id = '%s' WHERE name = 'assessment engine'" %
+        ae['client_id'])

--- a/tnth/prodanon/prodanon/transformers/contact_points.py
+++ b/tnth/prodanon/prodanon/transformers/contact_points.py
@@ -1,0 +1,7 @@
+"""Module to anonymize all PHI fields in ContactPoints table """
+
+
+def transform(cursor, custom_dir):
+    # remove any `value` fields, as some include user's phone numbers
+    cursor.execute("UPDATE contact_points SET value = null WHERE value is not null")
+    print(f"Updating {cursor.rowcount} contact_points rows")

--- a/tnth/prodanon/prodanon/transformers/emailmessages.py
+++ b/tnth/prodanon/prodanon/transformers/emailmessages.py
@@ -1,0 +1,15 @@
+"""Module to anonymize all PHI fields in email_messages table
+
+Might be nice to track recipients, for now purge.  (could track emails before obfuscation)
+
+Sender includes email addresses of staff.  Purged.
+
+The body of the emails are generally clean, except for introductions including names. Purged
+at this time.
+
+"""
+def transform(cursor, custom_dir):
+    cursor.execute(
+        "UPDATE email_messages SET recipients = '<redacted>', sender = '<redacted>', "
+        "body = '<redacted>'")
+    print(f"Updating {cursor.rowcount} email_messages rows")

--- a/tnth/prodanon/prodanon/transformers/grants.py
+++ b/tnth/prodanon/prodanon/transformers/grants.py
@@ -1,0 +1,7 @@
+"""Module to anonymize all PHI fields in Grants table """
+
+
+def transform(cursor, custom_dir):
+    # remove all grants - wouldn't want them functioning on different system
+    cursor.execute("DELETE FROM grants")
+    print(f"Deleted {cursor.rowcount} grants rows")

--- a/tnth/prodanon/prodanon/transformers/tokens.py
+++ b/tnth/prodanon/prodanon/transformers/tokens.py
@@ -1,0 +1,30 @@
+"""Module to anonymize all PHI fields in Tokens table """
+import os
+import yaml
+
+
+def insert_token(cursor, token):
+    # skip out if a match is found; simplifies development cycles
+    cursor.execute("SELECT count(*) FROM tokens WHERE client_id='%s'" % token['client_id'])
+    if cursor.fetchone()[0] == 1:
+        return
+
+    print("Inserting token '%s'" % token['name'])
+    values = (
+        token['client_id'], token['user_id'], token['token_type'],
+        token['access_token'], token['expires'], token['_scopes'])
+    insert_clause = (
+        "INSERT INTO tokens (client_id, user_id, token_type, access_token, expires, _scopes) "
+        "VALUES ('%s', %s, '%s', '%s', '%s', '%s')")
+
+    cursor.execute(insert_clause % values)
+
+
+def transform(cursor, custom_dir):
+    # remove all tokens from prod; add back in one for dev/test Assessment Engine
+    cursor.execute("DELETE FROM tokens")
+    print(f"Deleted {cursor.rowcount} tokens rows")
+
+    with open(os.path.join(custom_dir, "config.yaml"), 'r') as yamldata:
+        for token in yaml.safe_load(yamldata)['tokens']:
+            insert_token(cursor, token)

--- a/tnth/prodanon/prodanon/transformers/users.py
+++ b/tnth/prodanon/prodanon/transformers/users.py
@@ -1,0 +1,49 @@
+"""Module to anonymize all PHI fields in Users table"""
+import os
+import re
+import yaml
+from prodanon.config import Config
+
+prefix_pattern = re.compile(r'^(__.*__)')
+
+
+def email_for_user(id, current_email):
+    """Generate a reasonable email address
+
+    Needs to both anonymize and direct to an easy inbox for testing,
+    as well as maintain prefixes with special meaning
+    """
+    test_user, test_domain = Config.test_user_email.split("@")
+    email = f"{test_user}+{id}@{test_domain}"
+    match = prefix_pattern.match(current_email)
+    if match:
+        email = match.group(0) + email
+    return email
+
+
+def transform(cursor, custom_dir):
+    cursor.execute("SELECT id, email FROM users;")
+
+    with open(os.path.join(custom_dir, "config.yaml"), 'r') as yamlfile:
+        skip_ids = yaml.safe_load(yamlfile)['users']['preserve_ids']
+    updates = []
+    for id, em in cursor:
+        if id in skip_ids:
+            continue
+        fname = f"{id}_fn"
+        lname = f"{id}_ln"
+        birthdate = "1950-01-01"
+        email = email_for_user(id, em)
+
+        updates.append(
+            "UPDATE users SET"
+            f" first_name = '{fname}',"
+            f" last_name = '{lname}',"
+            f" birthdate = '{birthdate}',"
+            f" email = '{email}'"
+            f" WHERE id = {id};"
+        )
+
+    print(f"Updating {len(updates)} user rows")
+    for i in updates:
+        cursor.execute(i)

--- a/tnth/prodanon/requirements.dev.txt
+++ b/tnth/prodanon/requirements.dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+
+flake8
+pytest

--- a/tnth/prodanon/requirements.txt
+++ b/tnth/prodanon/requirements.txt
@@ -1,0 +1,3 @@
+psycopg2
+pyyaml
+

--- a/tnth/prodanon/tests/test_users.py
+++ b/tnth/prodanon/tests/test_users.py
@@ -1,0 +1,14 @@
+from prodanon.transformers.users import email_for_user
+
+
+def test_id_in_email():
+    b4 = 'user@gmail.com'
+    after = email_for_user(112233, b4)
+    assert after.split('+')[1].startswith("112233")
+    assert 'user' not in after
+    
+
+def test_nested_prefix():
+    b4 = '__deleted_1640755691____invite__achen2401+99000@gmail.com'
+    after = email_for_user(1234, b4)
+    assert after.startswith(b4[:32])

--- a/tnth/system-services.yaml
+++ b/tnth/system-services.yaml
@@ -13,7 +13,7 @@ services:
       POSTGRES_PASSWORD: ${PGPASSWORD:-wplatrop}
     volumes:
       - postgres-data:/var/lib/postgresql/data
-      - "./custom/db:/docker-entrypoint-initdb.d"
+      - "./config/db:/docker-entrypoint-initdb.d"
     ports:
       # only listen on localhost
       - "127.0.0.1:5432:5432"

--- a/tnth/system-services.yaml
+++ b/tnth/system-services.yaml
@@ -13,7 +13,7 @@ services:
       POSTGRES_PASSWORD: ${PGPASSWORD:-wplatrop}
     volumes:
       - postgres-data:/var/lib/postgresql/data
-      - "./config/db:/docker-entrypoint-initdb.d"
+      - "./custom/db:/docker-entrypoint-initdb.d"
     ports:
       # only listen on localhost
       - "127.0.0.1:5432:5432"


### PR DESCRIPTION
New .yaml and nested project `prodanon` to convert a production copy of the tnth database into a testable / PHI free version.

For proper function, secrets and identifiers from the target system (i.e. eproms-test prior to being replaced) need to be saved in `prodanon/prodanon/custom/config.yaml`  (such a file saved on `eproms-test:~pbugni/config.yaml`)